### PR TITLE
Don't error on unmatched files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,4 @@ npm i -D
 
 files=$(git diff --name-only $branch $(git merge-base $branch $mainbranch) | grep -E '.+\.('$2')$')
 
-npx eslint $files
+npx eslint $files --no-error-on-unmatched-pattern


### PR DESCRIPTION
Files that are deleted show up in the list of files changed.
This eslint option ignores if there are files in the list of
changed files that don't exist on the filesystem.